### PR TITLE
Add missing key in default configuration

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -23,6 +23,7 @@ namespace Invertus\dpdBaltics\Config;
 
 use Configuration;
 use DPDParcel;
+use DPDShipment;
 use Invertus\dpdBaltics\Collection\DPDProductInstallCollection;
 use Invertus\dpdBaltics\DTO\DPDProductInstall;
 use Module;
@@ -379,6 +380,7 @@ class Config
             self::IMPORT_LINES_SKIP => 1,
             self::PARCEL_DISTRIBUTION => DPDParcel::DISTRIBUTION_NONE,
             self::LABEL_PRINT_OPTION => 'download',
+            self::AUTO_VALUE_FOR_REF => DPDShipment::AUTO_VAL_REF_NONE,
         ];
     }
 


### PR DESCRIPTION
When importing settings csv file with empty `AUTO_VALUE_FOR_REF` column value, than the `SettingsImport` service try to get that value from default configuration, but the key of `AUTO_VALUE_FOR_REF` is not there. 

With this change we define default value in default configuration array to be `DPDShipment::AUTO_VAL_REF_NONE`