### PR TITLE
Fix price rules export

### DIFF
--- a/src/Repository/PriceRuleRepository.php
+++ b/src/Repository/PriceRuleRepository.php
@@ -226,7 +226,7 @@ class PriceRuleRepository extends AbstractEntityRepository
         $query->select('pr.id_dpd_price_rule');
         $query->from('dpd_price_rule', 'pr');
         $query->leftJoin('dpd_price_rule_carrier', 'prc', 'pr.id_dpd_price_rule = prc.id_dpd_price_rule');
-        $query->where('pr.id_dpd_price_rule = ' . (int)$priceRuleId . ' OR prc.all_carriers = 1');
+        $query->where('pr.id_dpd_price_rule = ' . (int)$priceRuleId . ' AND prc.all_carriers = 1');
 
         $result = $this->db->executeS($query);
         if (!is_array($result) || empty($result)) {


### PR DESCRIPTION
`PriceRuleRepository::findIsAllCarriersAssigned` method has wrong statement. 
Query return all price rules where field `all_carriers` is `1` when no matter what price rule id is in `where` clause.

With this change the method works as expected - it searches price rule which is assigned to work for all carriers. This way price rules export works as expected as well