### PR TITLE
Fix module tab permissions

### DIFF
--- a/dpdbaltics.php
+++ b/dpdbaltics.php
@@ -116,7 +116,7 @@ class DPDBaltics extends CarrierModule
         $this->author = 'Invertus';
         $this->tab = 'shipping_logistics';
         $this->description = 'DPD Baltics shipping integration';
-        $this->version = '3.2.12';
+        $this->version = '3.2.13';
         $this->ps_versions_compliancy = ['min' => '1.7.1.0', 'max' => _PS_VERSION_];
         $this->need_instance = 0;
         parent::__construct();

--- a/dpdbaltics.php
+++ b/dpdbaltics.php
@@ -159,17 +159,6 @@ class DPDBaltics extends CarrierModule
         return true;
     }
 
-    /**
-     * @return array
-     */
-    public function getTabs()
-    {
-        /** @var TabService $tabsService */
-        $tabsService = $this->getModuleContainer()->get('invertus.dpdbaltics.service.tab_service');
-
-        return $tabsService->getTabs();
-    }
-
     public function getContent()
     {
         Tools::redirectAdmin($this->context->link->getAdminLink(self::ADMIN_SETTINGS_CONTROLLER));

--- a/src/Install/Installer.php
+++ b/src/Install/Installer.php
@@ -317,23 +317,18 @@ class Installer
 
     private function installTabs()
     {
-        if (!Config::isPrestashopVersionBelow174()) {
-            return true;
-        }
         /** @var TabsCollection $tabCollection */
         $tabCollection = $this->tabFactory->getTabsCollection();
         $moduleName = $this->module->name;
-        $tabsInitializer = new TabsInitializer(_PS_VERSION_, $tabCollection, $moduleName);
-
-        return $tabsInitializer->initializeTabsByPsVersion();
+        
+        // TODO - create dedicated service to clean up the code
+        $tabsInstaller = new \Invertus\psModuleTabs\Service\TabsInstaller($tabCollection, $moduleName);
+        
+        return $tabsInstaller->installTabs();
     }
 
     private function uninstallTabs()
     {
-        if (!Config::isPrestashopVersionBelow174()) {
-            return true;
-        }
-
         /** @var TabsCollection $tabCollection */
         $tabCollection = $this->tabFactory->getTabsCollection()->getTabsCollection();
 

--- a/src/Service/TabService.php
+++ b/src/Service/TabService.php
@@ -47,7 +47,8 @@ class TabService
                 'name' => $this->module->displayName,
                 'class_name' => DPDBaltics::ADMIN_DPDBALTICS_MODULE_CONTROLLER,
                 'ParentClassName' => 'AdminParentShipping',
-                'parent' => 'AdminParentShipping'
+                'parent' => 'AdminParentShipping',
+                'visible' => true
             ],
             [
                 'name' => $this->module->l('Shipment', self::FILE_NAME),

--- a/upgrade/Upgrade-3.2.13.php
+++ b/upgrade/Upgrade-3.2.13.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * @author    INVERTUS, UAB www.invertus.eu <support@invertus.eu>
+ * @copyright Copyright (c) permanent, INVERTUS, UAB
+ * @license   Addons PrestaShop license limitation
+ * @see       /LICENSE
+ *
+ * International Registered Trademark & Property of INVERTUS, UAB
+ */
+
+use Invertus\dpdBaltics\Config\Config;
+use Invertus\dpdBaltics\Factory\TabFactory;
+use Invertus\dpdBaltics\Install\Installer;
+use Invertus\dpdBaltics\Provider\CurrentCountryProvider;
+use Invertus\psModuleTabs\Object\Tab;
+use Invertus\psModuleTabs\Object\TabsCollection;
+use Invertus\psModuleTabs\Service\TabsInitializer;
+use Invertus\psModuleTabs\Service\TabsInstaller;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * @return bool
+ *
+ * @throws PrestaShopDatabaseException
+ * @throws PrestaShopException
+ */
+function upgrade_module_3_2_13(DPDBaltics $module)
+{
+    $db = Db::getInstance();
+    $dbQuery = new DbQuery();
+    $dbQuery->select('id_tab');
+    $dbQuery->from('tab');
+    $dbQuery->where("`module` = '" . pSQL($module->name) . "'");
+    $tabs = $db->executeS($dbQuery);
+    foreach ($tabs as $tab) {
+        $tabClass = new TabCore($tab['id_tab']);
+        $tabClass->delete();
+    }
+
+    /** @var TabFactory $tabFactory */
+    $tabFactory = $module->getModuleContainer('invertus.dpdbaltics.factory.tab_factory');
+
+    $tabsInstaller = new TabsInstaller($tabFactory->getTabsCollection(), $module->name);
+    if (!$tabsInstaller->installTabs()) {
+        return false;
+    };
+
+    return true;
+}


### PR DESCRIPTION
This pull request fix issue #42 
Because of PrestaShop core issue [28308](https://github.com/PrestaShop/PrestaShop/issues/28308) module cannot use native PrestaShop module tabs register service. 

The problem with native PS functionality is that merchant cannot allow to use the module for it's team employees for [this kind of module tabs structure](https://github.com/DPDBaltics/PrestaShop-1.7/blob/832630e89dc96971297d3c2b1f28ef90f8ff537b/src/Service/TabService.php#L45). Only the SuperAdmin employee is allowed to use the module and this is a huge disadvantage for the module.

With this pull request module tab permissions work as expected and team employees can see the `DPDBaltics` tab in PrestaShop `IMPROVE > Shipping` tab menu.


