### PR TITLE
Create missing dpd shipment entity for order upon label saving

### DIFF
--- a/src/Service/ShipmentService.php
+++ b/src/Service/ShipmentService.php
@@ -361,6 +361,11 @@ class ShipmentService
 
         try {
             $shipmentId = $this->shipmentRepository->getIdByOrderId($order->id);
+            if (!$shipmendId) {
+                if ($this->createShipmentFromOrder($order)) {
+                    $shipmentId = $this->shipmentRepository->getIdByOrderId($order->id);
+                }
+            }
         } catch (Exception $e) {
             $response['message'] = $this->module->l(
                 sprintf('Could not fetch shipment order ID Error: %s', $e->getMessage(). 'ID cart: '. $order->id_cart


### PR DESCRIPTION
If merchant change order carrier from any to dpd, it is not possible to create dpd label, cause the error 
`Failed to save shipment to database Error: Savybė DPDShipment-&gtid_order yra tuščia.ID cart:<...>`

This error happens because `DPDShippment` entity for the order does not exist. With this pull request we create the `DPDShippment` and the merchant can save and print the label as usual.