### PR TITLE
Remove new lines from remark message before sending to dpd API

### DIFF
--- a/src/Util/StringUtility.php
+++ b/src/Util/StringUtility.php
@@ -111,6 +111,7 @@ class StringUtility
         $string = strtr($string, $table);
         // Currency symbols: £¤¥€  - we dont bother with them for now
         $string = preg_replace("/[^\x9\xA\xD\x20-\x7F]/u", "", $string);
+        $string = preg_replace("/[\r\n]*/","",$string);
         return $string;
     }
 }


### PR DESCRIPTION
When customer write message for the order with new lines it contains \r\n symbols which dpd api service does not like and fail when saving that message to a label. 

With this pull request we remove those bad characters from the remark message and merchant can save and print the label as usual.