### PR TITLE
fix dpd form auto close on input/select change

### DIFF
--- a/views/js/front/pudo.js
+++ b/views/js/front/pudo.js
@@ -108,7 +108,7 @@ $(document).ready(function () {
             }
 
             //Js to open extra content failed from theme, doing it manually.
-            if (!$(params.deliveryOption).next('.carrier-extra-content').is(':visible')) {
+            if ($(params.deliveryOption).next('.carrier-extra-content').length && !$(params.deliveryOption).next('.carrier-extra-content').is(':visible')) {
                 $('.carrier-extra-content').hide();
                 $(params.deliveryOption).next('.carrier-extra-content').slideDown();
             }


### PR DESCRIPTION
Fixes dpd form auto closing issue on any input/select(city, phone...) change on dpd form.

Issue:
https://github.com/DPDBaltics/PrestaShop-1.7/issues/38