### PR TITLE
DGS-344/ Allow override module front templates

### DIFF
--- a/dpdbaltics.php
+++ b/dpdbaltics.php
@@ -707,7 +707,7 @@ class DPDBaltics extends CarrierModule
             );
 
             $return .= $this->context->smarty->fetch(
-                $this->getLocalPath() . '/views/templates/hook/front/pudo-points.tpl'
+                'module:dpdbaltics/views/templates/hook/front/pudo-points.tpl'
             );
         }
 
@@ -1226,7 +1226,7 @@ class DPDBaltics extends CarrierModule
             ]
         );
         $html = $this->context->smarty->fetch(
-            $this->getLocalPath() . 'views/templates/hook/front/order-detail.tpl'
+            'module:dpdbaltics/views/templates/hook/front/order-detail.tpl'
         );
 
         return $html;

--- a/src/Builder/Template/Front/CarrierOptionsBuilder.php
+++ b/src/Builder/Template/Front/CarrierOptionsBuilder.php
@@ -112,7 +112,7 @@ class CarrierOptionsBuilder
         ]);
 
         return $this->context->smarty->fetch(
-            $this->moduleLocalPath . 'views/templates/hook/front/product-page-carriers.tpl'
+            'module:dpdbaltics/views/templates/hook/front/product-page-carriers.tpl'
         );
     }
 }

--- a/src/Presenter/DeliveryTimePresenter.php
+++ b/src/Presenter/DeliveryTimePresenter.php
@@ -57,7 +57,7 @@ class DeliveryTimePresenter
         );
 
         return $this->context->smarty->fetch(
-            $this->module->getLocalPath().'/views/templates/hook/front/carrier-delivery-time.tpl'
+             'module:dpdbaltics/views/templates/hook/front/carrier-delivery-time.tpl'
         );
     }
 }

--- a/src/Presenter/SameDayDeliveryMessagePresenter.php
+++ b/src/Presenter/SameDayDeliveryMessagePresenter.php
@@ -64,7 +64,7 @@ class SameDayDeliveryMessagePresenter
         );
 
         return $this->context->smarty->fetch(
-            $this->module->getLocalPath() . '/views/templates/hook/front/carrier-same-day-delivery-message.tpl'
+            'module:dpdbaltics/views/templates/hook/front/carrier-same-day-delivery-message.tpl'
         );
     }
 }

--- a/src/Service/CarrierPhoneService.php
+++ b/src/Service/CarrierPhoneService.php
@@ -106,7 +106,7 @@ class CarrierPhoneService
         );
 
         return $this->context->smarty->fetch(
-            $this->module->getLocalPath().'/views/templates/hook/front/carrier-phone-number.tpl'
+             'module:dpdbaltics/views/templates/hook/front/carrier-phone-number.tpl'
         );
     }
 


### PR DESCRIPTION
 Improved template rendering by allowing to override through theme.
 This method of rendering is available since 170 PrestaShop and DPD module is compatible since 171 PrestaShop