### PR TITLE
DGS-317 Fix for `ALL` selection price rules

### DIFF
--- a/src/Repository/PriceRuleRepository.php
+++ b/src/Repository/PriceRuleRepository.php
@@ -106,7 +106,7 @@ class PriceRuleRepository extends AbstractEntityRepository
             $query->innerJoin(
                 'dpd_zone_range',
                 'zr',
-                'prz.`id_dpd_zone` = zr.`id_dpd_zone`'
+                'prz.`id_dpd_zone` = zr.`id_dpd_zone` OR prz.all_zones = 1'
             );
 
             $query->where('zr.`id_country`= ' . (int) $deliveryAddress->id_country);

--- a/src/Repository/PriceRuleRepository.php
+++ b/src/Repository/PriceRuleRepository.php
@@ -87,7 +87,7 @@ class PriceRuleRepository extends AbstractEntityRepository
         bool $includeCountryCheck = false
     ) {
         $query = new DbQuery();
-        $query->select('prc.`id_dpd_price_rule`');
+        $query->select('DISTINCT prc.`id_dpd_price_rule`');
         $query->from('dpd_price_rule_carrier', 'prc');
         $query->innerJoin('dpd_price_rule', 'pr', 'pr.id_dpd_price_rule = prc.id_dpd_price_rule');
         $query->innerJoin(


### PR DESCRIPTION
Problem was that in SQL query when getting reference of `dpd_zone_range` it gets `0` because when selecting ALL, it gives `id_dpd_zone = 0` and makes `all_zones = 1`. So we need to check if nothing is in `id_dpd_zone` when we need to check for `all_zones = 1`

* Also made that it will return only unique values instead of repeating same price rule IDs

When all zones selected:
![image](https://github.com/user-attachments/assets/7a65d240-1190-40a5-90a6-9d6fc154a4c8)

When specific zones selected:
![image](https://github.com/user-attachments/assets/902004cd-6e3f-4145-a75d-83b316291567)

Code for reference with all zones when saving product settings:
![image](https://github.com/user-attachments/assets/325f2e5f-54cb-44f6-9143-e0fc0ec29506)

Also can impact #86 
