### PR TITLE
Fix Tools::displayPrice() deprecation for PS9 compatibility

### DIFF
--- a/src/Builder/Template/Front/CarrierOptionsBuilder.php
+++ b/src/Builder/Template/Front/CarrierOptionsBuilder.php
@@ -26,6 +26,7 @@ use Carrier;
 use Configuration;
 use Context;
 use Invertus\dpdBaltics\Config\Config;
+use Invertus\dpdBaltics\Infrastructure\Adapter\ToolsAdapter;
 use Invertus\dpdBaltics\Provider\ProductShippingCostProvider;
 use Invertus\dpdBaltics\Repository\CarrierRepository;
 use Invertus\dpdBaltics\Repository\PriceRuleRepository;
@@ -95,16 +96,14 @@ class CarrierOptionsBuilder
         }
 
         foreach ($dpdCarriers as $key => $dpdCarrier) {
-            $productShippingCost = Tools::displayPrice(
-                $this->productShippingCostProvider->getProductShippingCost($dpdCarrier['id_reference'], $idAddress)
-            );
+            $shippingCost = $this->productShippingCostProvider->getProductShippingCost($dpdCarrier['id_reference'], $idAddress);
 
-            if (!$productShippingCost) {
+            if (!$shippingCost) {
                 unset($dpdCarriers[$key]);
-
                 continue;
             }
 
+            $productShippingCost = ToolsAdapter::displayPrice($shippingCost, $this->context);
             $dpdCarriers[$key]['shipping_cost'] = $productShippingCost;
 
             $carrier = Carrier::getCarrierByReference($dpdCarrier['id_reference']);

--- a/src/Controller/AbstractAdminController.php
+++ b/src/Controller/AbstractAdminController.php
@@ -255,7 +255,6 @@ class AbstractAdminController extends ModuleAdminController
         /** @var ModuleLatestVersionValidator $moduleVersionValidator */
         $moduleVersionValidator = $this->module->getModuleContainer()->get('invertus.dpdbaltics.validator.module_latest_version_validator');
 
-        $isModuleVersionLatest = false; // Initialize variable to prevent undefined variable error
         try {
             $isModuleVersionLatest = $moduleVersionValidator->validate();
         } catch (\Exception $e) {

--- a/src/Controller/AbstractAdminController.php
+++ b/src/Controller/AbstractAdminController.php
@@ -255,6 +255,7 @@ class AbstractAdminController extends ModuleAdminController
         /** @var ModuleLatestVersionValidator $moduleVersionValidator */
         $moduleVersionValidator = $this->module->getModuleContainer()->get('invertus.dpdbaltics.validator.module_latest_version_validator');
 
+        $isModuleVersionLatest = false; // Initialize variable to prevent undefined variable error
         try {
             $isModuleVersionLatest = $moduleVersionValidator->validate();
         } catch (\Exception $e) {

--- a/src/Infrastructure/Adapter/ToolsAdapter.php
+++ b/src/Infrastructure/Adapter/ToolsAdapter.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace Invertus\dpdBaltics\Infrastructure\Adapter;
+
+use Invertus\dpdBaltics\Infrastructure\Utility\VersionUtility;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Adapter for Tools class compatibility across PrestaShop versions
+ */
+class ToolsAdapter
+{
+    /**
+     * Format price with currency symbol - compatible across PrestaShop versions
+     *
+     * @param float $price
+     * @param \Context|null $context
+     * @return string
+     */
+    public static function displayPrice($price, $context = null)
+    {
+        $context = $context ?: \Context::getContext();
+        
+        if (VersionUtility::isPsVersionGreaterOrEqualTo('9.0.0')) {
+            // PrestaShop 9+ approach
+            return $context->getCurrentLocale()->formatPrice(
+                $price,
+                $context->currency->iso_code
+            );
+        }
+        
+        // PrestaShop 8 and below approach
+        return \Tools::displayPrice($price);
+    }
+}

--- a/src/Infrastructure/Utility/VersionUtility.php
+++ b/src/Infrastructure/Utility/VersionUtility.php
@@ -50,4 +50,5 @@ class VersionUtility
     {
         return version_compare(_PS_VERSION_, $version, '=');
     }
+
 }


### PR DESCRIPTION
Fix Tools::displayPrice() deprecation for PrestaShop 9 compatibility

- Resolves fatal error: Call to undefined method Tools::displayPrice()
- Adds ToolsAdapter for backward compatibility between PS8 and PS9
- Updates CarrierOptionsBuilder to use the adapter
- Maintains full backward compatibility