### PR TITLE
DGS-410 Fix double discount calculation in COD label goods price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,10 @@
 - Added warning when module have outdated version
 - Improved module performance
 
+## [3.3.1] - 2025-11-19
+### Fixed
+- Fixed incorrect COD label amount when discount code is applied
+
 ## [3.3.0]
 - Added PrestaShop 9 compatibility
 - Fixed issue with price rule "All"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,11 +182,10 @@
 - Added warning when module have outdated version
 - Improved module performance
 
-## [3.3.1] - 2025-11-19
-### Fixed
-- Fixed incorrect COD label amount when discount code is applied
-
 ## [3.3.0]
 - Added PrestaShop 9 compatibility
 - Fixed issue with price rule "All"
 - Fixed other minor issues
+
+## [3.3.1]
+- Fixed incorrect COD label amount when discount code is applied

--- a/dpdbaltics.php
+++ b/dpdbaltics.php
@@ -85,7 +85,7 @@ class DPDBaltics extends CarrierModule
         $this->author = 'Invertus';
         $this->tab = 'shipping_logistics';
         $this->description = 'DPD Baltics shipping integration';
-        $this->version = '3.3.0';
+        $this->version = '3.3.1';
         $this->ps_versions_compliancy = ['min' => '1.7.1.0', 'max' => _PS_VERSION_];
         $this->need_instance = 0;
         parent::__construct();

--- a/src/Service/ShipmentService.php
+++ b/src/Service/ShipmentService.php
@@ -232,7 +232,6 @@ class ShipmentService
             $parcelWeight += $product['weight'] * $product['product_quantity'];
         }
 
-        $goodsPrice = $this->calculateParcelPriceWithOrderDiscount($order, $goodsPrice);
         $shipment = $this->createShipment($order, $idProduct, $isTestMode, 1, $parcelWeight, $goodsPrice);
 
         if (!$shipment->id) {


### PR DESCRIPTION
Issue: When discount codes are applied, the COD label shows incorrect goods price because discount is subtracted twice from order total.

Root cause: createNonDistributedShipment method was subtracting order discount from order.total_paid, which already includes all discounts.

Solution: Removed duplicate discount calculation in createNonDistributedShipment method. The order.total_paid value correctly reflects the final amount customer pays.

Also fixed syntax error on line 283 (removed stray character).

https://invertus.atlassian.net/browse/DGS-410