### PR TITLE
fix Poland parcel shops and various null pointer errors

### DIFF
--- a/config/service.yml
+++ b/config/service.yml
@@ -269,6 +269,8 @@ services:
     arguments:
       - '@invertus.dpdbaltics.factory.parcel_tracking_url_factory'
       - '@dpdbaltics'
+      - '@invertus.dpdbaltics.logger.logger'
+
   invertus.dpdbaltics.service.carrier.prestashop_carrier_regeneration_handler:
     class: 'Invertus\dpdBaltics\Service\Carrier\PrestashopCarrierRegenerationHandler'
     arguments:
@@ -282,6 +284,7 @@ services:
     arguments:
       - '@invertus.dpdbaltics.factory.parcel_tracking_url_factory'
       - '@dpdbaltics'
+      - '@invertus.dpdbaltics.logger.logger'
 
   invertus.dpdbaltics.service.label_printing_service:
     class: 'Invertus\dpdBaltics\Service\LabelPrintingService'

--- a/config/services.yml
+++ b/config/services.yml
@@ -1,0 +1,10 @@
+services:
+  _defaults:
+    public: true
+    autowire: false
+    autoconfigure: false
+
+  Invertus\dpdBaltics\ConsoleCommand\UpdateParcelShopsCommand:
+    class: 'Invertus\dpdBaltics\ConsoleCommand\UpdateParcelShopsCommand'
+    tags:
+      - { name: 'console.command' }

--- a/dpdbaltics.php
+++ b/dpdbaltics.php
@@ -958,9 +958,10 @@ class DPDBaltics extends CarrierModule
         $hasParcelShops = false;
         if ($parcelShops) {
             if ($selectedPudo->pudo_id) {
-                $selectedPudoService = $parcelShopService->getParcelShopByShopId($selectedPudo->pudo_id)[0];
+                $pudoShops = $parcelShopService->getParcelShopByShopId($selectedPudo->pudo_id);
+                $selectedPudoService = !empty($pudoShops) ? $pudoShops[0] : null;
             } else {
-                $selectedPudoService = $parcelShops[0];
+                $selectedPudoService = isset($parcelShops[0]) ? $parcelShops[0] : null;
             }
             $hasParcelShops = true;
         }

--- a/dpdbaltics.php
+++ b/dpdbaltics.php
@@ -214,6 +214,12 @@ class DPDBaltics extends CarrierModule
                     'isOnePageCheckout' => $opcModuleCompatibilityValidator->isOpcModuleInUse()
                 ]
             ]);
+        } else {
+            Media::addJsDef([
+                'dpdbaltics' => [
+                    'isOnePageCheckout' => false
+                ]
+            ]);
         }
 
         /** @var \Invertus\dpdBaltics\Provider\CurrentCountryProvider $currentCountryProvider */

--- a/src/ConsoleCommand/UpdateParcelShopsCommand.php
+++ b/src/ConsoleCommand/UpdateParcelShopsCommand.php
@@ -23,15 +23,12 @@ namespace Invertus\dpdBaltics\ConsoleCommand;
 use Country;
 use Invertus\dpdBaltics\Provider\ZoneRangeProvider;
 use Invertus\dpdBaltics\Service\Import\API\ParcelShopImport;
+use Module;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-
-if (!defined('_PS_VERSION_')) {
-    exit;
-}
 
 /**
  * CLI command for importing parcel shops.
@@ -45,36 +42,31 @@ if (!defined('_PS_VERSION_')) {
  */
 class UpdateParcelShopsCommand extends Command
 {
+    protected static $defaultName = 'dpdbaltics:update-parcel-shops';
+
     /**
-     * @var LoggerInterface
+     * @var LoggerInterface|null
      */
     private $logger;
 
     /**
-     * @var ParcelShopImport
+     * @var ParcelShopImport|null
      */
     private $parcelShopImport;
 
     /**
-     * @var ZoneRangeProvider
+     * @var ZoneRangeProvider|null
      */
     private $zoneRangeProvider;
 
-    public function __construct(
-        LoggerInterface $logger,
-        ParcelShopImport $parcelShopImport,
-        ZoneRangeProvider $zoneRangeProvider
-    ) {
-        parent::__construct();
-        $this->logger = $logger;
-        $this->parcelShopImport = $parcelShopImport;
-        $this->zoneRangeProvider = $zoneRangeProvider;
-    }
+    /**
+     * @var \DPDBaltics|null
+     */
+    private $module;
 
     protected function configure()
     {
         $this
-            ->setName('dpdbaltics:update-parcel-shops')
             ->setDescription('Import/update DPD parcel shops from API')
             ->addOption(
                 'country',
@@ -106,8 +98,36 @@ EOF
             );
     }
 
+    /**
+     * Initialize services from the module's container.
+     */
+    private function initServices()
+    {
+        if ($this->module !== null) {
+            return;
+        }
+
+        $this->module = Module::getInstanceByName('dpdbaltics');
+
+        if (!$this->module) {
+            throw new \RuntimeException('DPD Baltics module is not installed or not active.');
+        }
+
+        $this->parcelShopImport = $this->module->getService('invertus.dpdbaltics.service.import.api.parcel_shop_import');
+        $this->zoneRangeProvider = $this->module->getService('invertus.dpdbaltics.provider.zone_range_provider');
+        $this->logger = $this->module->getService('invertus.dpdbaltics.logger.logger');
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        // Initialize services from module's container
+        try {
+            $this->initServices();
+        } catch (\Exception $e) {
+            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+            return 1;
+        }
+
         $country = $input->getOption('country');
         $all = $input->getOption('all');
 
@@ -167,11 +187,13 @@ EOF
                 $output->writeln(sprintf('<error>ERROR</error> (%ss)', $elapsed));
                 $output->writeln(sprintf('  <error>%s</error>', $e->getMessage()));
 
-                $this->logger->error(sprintf(
-                    '[CLI] Import failed for %s: %s',
-                    $countryCode,
-                    $e->getMessage()
-                ));
+                if ($this->logger) {
+                    $this->logger->error(sprintf(
+                        '[CLI] Import failed for %s: %s',
+                        $countryCode,
+                        $e->getMessage()
+                    ));
+                }
             }
 
             $output->writeln('');

--- a/src/Service/API/ShipmentApiService.php
+++ b/src/Service/API/ShipmentApiService.php
@@ -108,15 +108,18 @@ class ShipmentApiService
         $hasAddressFields = (bool) !$postCode || !$firstName || !$address->city || !$country;
 
         // Post code might be wrong in order adress, so we set terminal post code instead
+        $selectedParcel = null;
         if ($shipmentData->isPudo()) {
             $parcel = $this->parcelShopService->getParcelShopByShopId($shipmentData->getSelectedPudoId());
-            $selectedParcel = is_array($parcel) ? reset($parcel) : $parcel;
-            $postCode = $selectedParcel->getPCode();
-            $address->address1 = $selectedParcel->getStreet();
+            $selectedParcel = is_array($parcel) && !empty($parcel) ? reset($parcel) : $parcel;
+            if ($selectedParcel && is_object($selectedParcel)) {
+                $postCode = $selectedParcel->getPCode();
+                $address->address1 = $selectedParcel->getStreet();
+            }
         }
 
         // IF prestashop allows, we take selected parcel terminal address in case information is missing in checkout address in specific cases.
-        if (($hasAddressFields) && $shipmentData->isPudo()) {
+        if (($hasAddressFields) && $shipmentData->isPudo() && $selectedParcel && is_object($selectedParcel)) {
             $firstName = $selectedParcel->getCompany();
             $address->address1 = $selectedParcel->getStreet();
             $address->city = $selectedParcel->getCity();
@@ -197,7 +200,7 @@ class ShipmentApiService
             $address1 = $selectedPudo->street;
             $city = $selectedPudo->city;
             $countryIso = $selectedPudo->country_code;
-            $postCode = $selectedPudo->post_code;
+            $postCode = preg_replace('/[^0-9]/', '', $selectedPudo->post_code);
         } else {
             $address1 = $address->address1;
             $city = $address->city;

--- a/views/templates/hook/admin/partials/pudo-info.tpl
+++ b/views/templates/hook/admin/partials/pudo-info.tpl
@@ -16,6 +16,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  *}
+{if $selectedPudo}
 <div class="col-lg-12 pudo-info-container">
     <input class="hidden d-none form-control" name="selected-pudo-id" value="{$selectedPudo->getParcelShopId()|escape:'htmlall':'UTF-8'}">
     <input class="hidden d-none form-control" name="selected_pudo_iso_code" value="{$selectedPudo->getCountry()|escape:'htmlall':'UTF-8'}">
@@ -69,3 +70,12 @@
         </div>
     </div>
 </div>
+{else}
+<div class="col-lg-12 pudo-info-container">
+    <div class="card-body">
+        <div class="alert alert-info">
+            {l s='No pickup point selected' mod='dpdbaltics'}
+        </div>
+    </div>
+</div>
+{/if}

--- a/views/templates/hook/front/partials/markers-list.tpl
+++ b/views/templates/hook/front/partials/markers-list.tpl
@@ -109,9 +109,9 @@
         </ul>
     </div>
 {else}
-    <div class="dpd-services-block">
-        <div class="alert alert-warning">
-            {l s='No pickup points found' mod='dpdbaltics'}
+    <div class="dpd-services-block dpd-no-pudo-message">
+        <div class="alert alert-info">
+            {l s='Select a city to view pickup points' mod='dpdbaltics'}
         </div>
     </div>
 {/if}


### PR DESCRIPTION
- Add logger argument to ParcelTrackingEmailHandler service definitions
- Fix null pointer errors when accessing parcel shop arrays
- Fix postcode formatting for PUDO return shipments (strip hyphens)
- Add null checks for selectedPudo in admin template
- Change frontend message from "No pickup points found" to "Select a city to view pickup points"
- Update console command to lazy-load services from module container
- Register console command with PrestaShop's Symfony container
- Fix dpdbaltics JS variable undefined on standard checkout (non-OPC), which prevented PUDO pickup point selection from working

## Note
  Vendor file change (not in this PR) - timeout increased to 60s in:
  `vendor/invertus/dpdbaltics-api/src/Factory/APIRequest/ApiClient.php`