### PR TITLE
DGS-415 fix PHP 8.1 null deprecation in AddressAdapter preg_replace

### DIFF
--- a/src/Adapter/AddressAdapter.php
+++ b/src/Adapter/AddressAdapter.php
@@ -88,7 +88,7 @@ class AddressAdapter
     {
         $countryCodePosition = $this->getCountryCodePosition($country);
 
-        $postCode = preg_replace("/[^a-zA-Z0-9]+/", "", $postCode);
+        $postCode = preg_replace("/[^a-zA-Z0-9]+/", "", $postCode ?? '');
         // If C doesn't exist in zip code format - don't modify the zip code
         if (false === $countryCodePosition) {
             return $postCode;
@@ -120,7 +120,7 @@ class AddressAdapter
     /** Changes zip code format from pudo service to the one used in prestashop as based on country and returns it*/
     public function getFormattedZipCodePudoToPrestashop($iso, $zipCode)
     {
-        $zipCode = preg_replace("/[^a-zA-Z0-9]+/", "", $zipCode);
+        $zipCode = preg_replace("/[^a-zA-Z0-9]+/", "", $zipCode ?? '');
         $country = new Country(Country::getByIso($iso));
         $formattedZipCode = $zipCode;
         $isoAdded = false;
@@ -153,6 +153,6 @@ class AddressAdapter
             return str_replace(' ', '', $postCode);
         }
 
-        return preg_replace('/[^0-9]/', '', $postCode);
+        return preg_replace('/[^0-9]/', '', $postCode ?? '');
     }
 }


### PR DESCRIPTION
## Summary
- Fix PHP 8.1 deprecation warning when null is passed to `preg_replace()` in `AddressAdapter.php`
- Added null coalescing operator (`?? ''`) to all 3 `preg_replace()` calls (lines 91, 123, 156)
- Prevents `TypeError` on PHP 8.2+ where this deprecation becomes a fatal error

## Test plan
- [x] Reproduced deprecation on PHP 8.1.33 with null postcode passed to `AddressAdapter->getZipCode()`
- [x] Verified fix resolves the deprecation — error log clean after applying fix
- [x] Verify checkout flow works normally with valid postcodes