### PR TITLE
DGS-417 Fix shipment creation failing when Predict SMS service is mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,9 @@
 - Added warning when module have outdated version
 - Improved module performance
 
+## [3.3.1]
+- Fixed shipment creation failing for accounts requiring Predict SMS service
+
 ## [3.3.0]
 - Added PrestaShop 9 compatibility
 - Fixed issue with price rule "All"

--- a/src/Service/API/ShipmentApiService.php
+++ b/src/Service/API/ShipmentApiService.php
@@ -234,6 +234,7 @@ class ShipmentApiService
         $shipmentCreationRequest->setOrderNumber3($shipmentData->getReference4());
         $shipmentCreationRequest->setWeight($shipmentData->getWeight());
         $shipmentCreationRequest->setIdmSmsNumber($shipmentData->getPhone());
+        $shipmentCreationRequest->setPredict('y');
         $shipmentCreationRequest->setOrderNumber($shipmentData->getReference1());
 
         return $shipmentCreationRequest;


### PR DESCRIPTION
## Summary
- Enable DPD Predict SMS service by setting `predict=y` on all shipment creation requests
- Some DPD client accounts (notably Latvia) require this parameter, causing shipment creation to fail with: *"Additional Predict sms service is mandatory or part of main service, but your request doesn't have a Predict sms service"*
- The `predict` field was already supported by the API library but never set by the module

## Test plan
- [ ] Verify shipment creation works for Latvia accounts that require Predict SMS
- [ ] Verify shipment creation still works for Lithuania and Estonia accounts
- [ ] Verify PUDO and COD shipment types are not affected