### PR TITLE
Fix pudo pickup points not reloading on city change

### DIFF
--- a/views/js/front/pudo.js
+++ b/views/js/front/pudo.js
@@ -157,9 +157,9 @@ $(document).ready(function () {
         $(document).on('click', '.dpd-pudo-select', selectPickupPointEvent);
     }
 
-    // $(document).on('change', 'select[name="dpd-city"]',function (){
-    //     searchPudoServicesEvent($(this));
-    // });
+    $(document).on('change', 'select[name="dpd-city"]', function () {
+        searchPudoServicesEvent($(this));
+    });
 
     function resizeMapEvent(e) {
         for (var idReference in dpdMap) {


### PR DESCRIPTION
## Summary
- Uncommented the city dropdown change event handler in `pudo.js` that triggers parcel point reload
- Previously, switching cities in the pickup point selector did nothing until the address was entered

## Root cause
The `searchPudoServicesEvent` call on city change was commented out since the initial commit (2021), causing pickup points to only reload on carrier switch or address entry.