### PR TITLE
Fix admin pudo pickup point display for non-LT orders

### DIFF
--- a/controllers/admin/AdminDPDBalticsAjaxShipmentsController.php
+++ b/controllers/admin/AdminDPDBalticsAjaxShipmentsController.php
@@ -105,6 +105,14 @@ class AdminDPDBalticsAjaxShipmentsController extends AbstractAdminController
                     $carrierId = (int) Tools::getValue('carrier_id');
                     $carrier = new Carrier($carrierId);
                 }
+
+                $countryCode = null;
+                if (Validate::isLoadedObject($order)) {
+                    /** @var \Invertus\dpdBaltics\Provider\CurrentCountryProvider $currentCountryProvider */
+                    $currentCountryProvider = $this->module->getModuleContainer('invertus.dpdbaltics.provider.current_country_provider');
+                    $countryCode = $currentCountryProvider->getCountryIsoCodeByAddress($order->id_address_delivery);
+                }
+
                 /** @var PudoService $pudoService */
                 $pudoService = $this->module->getModuleContainer('invertus.dpdbaltics.service.pudo_service');
                 try {
@@ -112,7 +120,8 @@ class AdminDPDBalticsAjaxShipmentsController extends AbstractAdminController
                         $pudoService->searchPudoServices(
                             $cityName,
                             $carrier->id_reference,
-                            $cartId
+                            $cartId,
+                            $countryCode
                         )
                     );
                 } catch (Exception $e) {

--- a/src/Provider/CurrentCountryProvider.php
+++ b/src/Provider/CurrentCountryProvider.php
@@ -95,7 +95,7 @@ class CurrentCountryProvider
      *
      * @return string|null
      */
-    private function getCountryIsoCodeByAddress($idAddress)
+    public function getCountryIsoCodeByAddress($idAddress)
     {
         $address = new Address($idAddress);
 

--- a/src/Repository/ParcelShopRepository.php
+++ b/src/Repository/ParcelShopRepository.php
@@ -50,7 +50,7 @@ class ParcelShopRepository extends AbstractEntityRepository
     public function getShopsByCity($country, $city)
     {
         $query = new DbQuery();
-        $query->select('*');
+        $query->select('s.*');
         $query->from('dpd_shop', 's');
         $query->where('s.`country` = "' . pSQL($country) . '" AND s.`city` = "' . pSQL($city) . '"');
 
@@ -60,11 +60,9 @@ class ParcelShopRepository extends AbstractEntityRepository
     public function getShopsByShopId($shopId)
     {
         $query = new DbQuery();
-        $query->select('*');
+        $query->select('s.*');
         $query->from('dpd_shop', 's');
-        $query->innerJoin('dpd_shop_work_hours', 'wh', 's.parcel_shop_id = wh.parcel_shop_id');
         $query->where('s.`parcel_shop_id` = "' . pSQL($shopId) . '"');
-        $query->groupBy('s.parcel_shop_id');
 
         return $this->db->executeS($query);
     }

--- a/src/Service/PudoService.php
+++ b/src/Service/PudoService.php
@@ -186,31 +186,29 @@ class PudoService
         return true;
     }
 
-    public function searchPudoServices($city, $carrierId, $cartId)
+    public function searchPudoServices($city, $carrierId, $cartId, $countryCode = null)
     {
-        $cart = null;
+        if (!$countryCode) {
+            $cart = null;
 
-        if ($cartId) {
-            $cart = new Cart($cartId);
+            if ($cartId) {
+                $cart = new Cart($cartId);
+            }
+            /** @var CurrentCountryProvider $currentCountryProvider */
+            $currentCountryProvider = $this->module->getModuleContainer('invertus.dpdbaltics.provider.current_country_provider');
+            $countryCode = $currentCountryProvider->getCurrentCountryIsoCode($cart);
         }
-        /** @var CurrentCountryProvider $currentCountryProvider */
-        $currentCountryProvider = $this->module->getModuleContainer('invertus.dpdbaltics.provider.current_country_provider');
-        $countryCode = $currentCountryProvider->getCurrentCountryIsoCode($cart);
 
         /** @var ParcelShopService $parcelShopService */
-        /** @var PudoService $pudoService */
-        $parcelShopService= $this->module->getModuleContainer('invertus.dpdbaltics.service.parcel.parcel_shop_service');
-        $pudoService = $this->module->getModuleContainer('invertus.dpdbaltics.service.pudo_service');
+        $parcelShopService = $this->module->getModuleContainer('invertus.dpdbaltics.service.parcel.parcel_shop_service');
 
         /** @var ParcelShop[] $parcelShops */
         $parcelShops = $parcelShopService->getParcelShopsByCountryAndCity($countryCode, $city);
 
-        $pudoServices = $pudoService->setPudoServiceTypes($parcelShops);
-        $pudoServices = $pudoService->formatPudoServicesWorkHours($pudoServices);
+        $pudoServices = $this->setPudoServiceTypes($parcelShops);
+        $pudoServices = $this->formatPudoServicesWorkHours($pudoServices);
 
-        /** @var PudoRepository $pudoRepo */
-        $pudoRepo = $this->module->getModuleContainer('invertus.dpdbaltics.repository.pudo_repository');
-        $pudoId = $pudoRepo->getIdByCart($cartId);
+        $pudoId = $this->pudoRepository->getIdByCart($cartId);
         $selectedPudo = new DPDPudo($pudoId);
 
         $this->smarty->assign(

--- a/views/js/front/pudo.js
+++ b/views/js/front/pudo.js
@@ -157,9 +157,9 @@ $(document).ready(function () {
         $(document).on('click', '.dpd-pudo-select', selectPickupPointEvent);
     }
 
-    // $(document).on('change', 'select[name="dpd-city"]',function (){
-    //     searchPudoServicesEvent($(this));
-    // });
+    $(document).on('change', 'select[name="dpd-city"]', function () {
+        searchPudoServicesEvent($(this));
+    });
 
     function resizeMapEvent(e) {
         for (var idReference in dpdMap) {


### PR DESCRIPTION
## Summary
- Fixed admin order page showing "No pickup point selected" for orders with non-Lithuanian delivery addresses (e.g. Poland)
- Root cause 1: Country code derived from cart context fell back to `WEB_SERVICE_COUNTRY` (LT) instead of the order's actual delivery address
- Root cause 2: `ParcelShopRepository::getShopsByShopId()` used `INNER JOIN dpd_shop_work_hours` which returned no results for shops without work hours records

## Changes
- **AdminDPDBalticsAjaxShipmentsController**: Derive country code from order's delivery address via `CurrentCountryProvider` and pass to pudo search
- **CurrentCountryProvider**: Make `getCountryIsoCodeByAddress()` public for reuse
- **ParcelShopRepository**: Remove unnecessary `INNER JOIN` + `GROUP BY` in `getShopsByShopId()` (work hours are already fetched separately by `ShopFactory`)
- **PudoService**: Accept optional `$countryCode` param, use `$this` instead of container self-reference, use constructor-injected `pudoRepository`

## Test plan
- [ ] Open admin order page for a non-LT pudo order (e.g. Poland)
- [ ] Verify the selected pickup point is displayed with address, city, country
- [ ] Click "Search" and verify pudo results load for the correct country
- [ ] Verify LT orders still work correctly