### PR TITLE
DGS-425 Fix chosen select width on carrier switch in checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,3 +199,4 @@
 - Fixed automatic PUDO point pre-selection in LIST mode
 - Fixed PUDO shipment CSS styling
 - Added timeframes to shipment request
+- Fixed phone area code, city and street select width rendering as 0px when switching carriers in checkout

--- a/views/js/front/pudo.js
+++ b/views/js/front/pudo.js
@@ -157,9 +157,9 @@ $(document).ready(function () {
         $(document).on('click', '.dpd-pudo-select', selectPickupPointEvent);
     }
 
-    // $(document).on('change', 'select[name="dpd-city"]',function (){
-    //     searchPudoServicesEvent($(this));
-    // });
+    $(document).on('change', 'select[name="dpd-city"]', function () {
+        searchPudoServicesEvent($(this));
+    });
 
     function resizeMapEvent(e) {
         for (var idReference in dpdMap) {

--- a/views/js/front/pudo.js
+++ b/views/js/front/pudo.js
@@ -107,10 +107,16 @@ $(document).ready(function () {
                 return;
             }
 
+            var $extraContent = $(params.deliveryOption).next('.carrier-extra-content');
+
             //Js to open extra content failed from theme, doing it manually.
-            if (params.deliveryOption.length > 0 && !$(params.deliveryOption).next('.carrier-extra-content').is(':visible') && !dpdbaltics.isOnePageCheckout) {
+            if (params.deliveryOption.length > 0 && !$extraContent.is(':visible') && !dpdbaltics.isOnePageCheckout) {
                 $('.carrier-extra-content').hide();
-                $(params.deliveryOption).next('.carrier-extra-content').slideDown();
+                $extraContent.slideDown(400, function () {
+                    DPDrefreshChosenSelects($extraContent);
+                });
+            } else {
+                DPDrefreshChosenSelects($extraContent);
             }
 
             var deliveryOption = params.deliveryOption;
@@ -698,6 +704,38 @@ function DPDremoveMessage(parent) {
 function dpdHidePopOversEvent() {
     $('.dpd-more-information').each(function () {
         $(this).popover('hide');
+    });
+}
+
+/**
+ * Re-initialize Chosen widgets inside the given container so they pick up the
+ * correct width once the carrier extra content is visible. Without this,
+ * Chosen instances initialized while the parent was hidden render at 0px.
+ * Retries while the container is still hidden (theme animations, OPC modules).
+ */
+function DPDrefreshChosenSelects($container, attempts) {
+    if (!$container || !$container.length || typeof $.fn.chosen !== 'function') {
+        return;
+    }
+
+    attempts = attempts || 0;
+
+    if (!$container.is(':visible') || $container.outerWidth() === 0) {
+        if (attempts >= 10) {
+            return;
+        }
+        setTimeout(function () {
+            DPDrefreshChosenSelects($container, attempts + 1);
+        }, 100);
+        return;
+    }
+
+    $container.find('select.chosen-select').each(function () {
+        var $select = $(this);
+        if ($select.data('chosen')) {
+            $select.chosen('destroy');
+        }
+        $select.chosen({inherit_select_classes: true});
     });
 }
 


### PR DESCRIPTION
## Summary
- Phone area code, city and street selects rendered with 0px width when switching carriers via AJAX in checkout (PS9 default checkout and steasycheckout). Fields displayed correctly only after a full page refresh.
- Root cause: Chosen widgets were initialized while the parent `.carrier-extra-content` was still hidden, so they calculated the wrong width. PrestaShop 9 hides all carrier extra content blocks and slides down only the selected one.
- Fix: Re-initialize Chosen widgets (destroy + re-init) once the carrier extra content is actually visible. Uses the slideDown completion callback for default checkout and a short polling loop for OPC modules and theme animations.

## Test plan
- [ ] PS 9.0.0 / 9.0.3 default checkout: switch between DPD carriers and verify phone area code, city and street selects render with full width
- [ ] PS 9 with steasycheckout: switch between DPD carriers and verify the same
- [ ] PS 8.x regression: confirm carrier switching still works and selects render correctly
- [ ] Verify city change still updates streets and PUDO points (no regression in pudo-search.js flow)