### PR TITLE
Fix DPDBaltics sidebar item disappearing on module pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,3 +199,4 @@
 - Fixed automatic PUDO point pre-selection in LIST mode
 - Fixed PUDO shipment CSS styling
 - Added timeframes to shipment request
+- Fixed DPDBaltics menu item disappearing from sidebar when navigating to module pages

--- a/views/css/admin/global_module.css
+++ b/views/css/admin/global_module.css
@@ -16,6 +16,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
-#subtab-AdminDPDBalticsModule{
+#subtab-AdminDPDBalticsModule > ul,
+#subtab-AdminDPDBalticsModule .submenu {
     display: none;
 }


### PR DESCRIPTION
## Summary
- `views/css/admin/global_module.css` had a rule `#subtab-AdminDPDBalticsModule { display: none }` that hid the entire `<li>` wrapping the DPDBaltics sidebar link, not just nested children.
- This CSS is loaded by `AbstractAdminController::setMedia()` on every DPDBaltics admin controller, so the DPDBaltics navigation item vanished from the sidebar whenever a user opened any DPDBaltics page (Shipment, Courier request, etc.).
- Replaced with a narrower selector that targets only nested submenu elements, keeping the parent link visible.

## Test plan
- [x] Reproduced bug on PS 1.7.8.9: navigated to `AdminDPDBalticsShipment`, confirmed `#subtab-AdminDPDBalticsModule` had `display: none` via DOM inspection.
- [x] Applied fix and verified `#subtab-AdminDPDBalticsModule` now renders with `display: block` and the link is visually present in the sidebar (screenshot).
- [x] Verified no regression on PS core controllers (`AdminCarriers`, `AdminDashboard`): DPDBaltics still appears in sidebar as before.
- [x] Verified top tab strip on the page (`#head_tabs`) still renders all 10 child tabs (Shipment, Orders returns, Courier request, Addresses, etc.).
- [ ] Verify same fix on PS 8.x and PS 9.x.