### PR TITLE
Fix Shipment list sorting on joined-table columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,3 +186,7 @@
 - Added PrestaShop 9 compatibility
 - Fixed issue with price rule "All"
 - Fixed other minor issues
+
+## [3.3.1]
+- Fixed sorting on Shipment list columns from joined tables (Tracking number, Receiver, Address, City)
+- Changed default sort on Shipment list to show latest shipments first

--- a/controllers/admin/AdminDPDBalticsShipmentController.php
+++ b/controllers/admin/AdminDPDBalticsShipmentController.php
@@ -49,12 +49,15 @@ class AdminDPDBalticsShipmentController extends AbstractAdminController
     private function initList()
     {
         $this->list_no_link = true;
+        $this->_defaultOrderBy = 'id_dpd_shipment';
+        $this->_defaultOrderWay = 'DESC';
 
         $this->fields_list = [
             'tracking_number' => [
                 'title' => $this->module->l('Tracking number'),
                 'type' => 'text',
-                'havingFilter' => true
+                'havingFilter' => true,
+                'order_key' => 'oc!tracking_number',
             ],
             'date_print' => [
                 'title' => $this->module->l('Printing date'),
@@ -69,17 +72,20 @@ class AdminDPDBalticsShipmentController extends AbstractAdminController
             'receiver_name' => [
                 'title' => $this->module->l('Receiver'),
                 'type' => 'text',
-                'havingFilter' => true
+                'havingFilter' => true,
+                'order_key' => 'c!lastname',
             ],
             'address1' => [
                 'title' => $this->module->l('Address'),
                 'type' => 'text',
-                'havingFilter' => true
+                'havingFilter' => true,
+                'order_key' => 'addr!address1',
             ],
             'city' => [
                 'title' => $this->module->l('City'),
                 'type' => 'text',
-                'havingFilter' => true
+                'havingFilter' => true,
+                'order_key' => 'addr!city',
             ],
             'reference1' => [
                 'title' => $this->module->l('Cust Ref 1'),


### PR DESCRIPTION
## Summary
- Tracking number, Receiver, Address, and City columns on the admin Shipment list now sort correctly. They come from joined tables (`order_carrier`, `customer`, `address`); previously PrestaShop fell back to the main shipment table and produced no useful ordering.
- Default sort is now `id_dpd_shipment DESC` so the latest shipments appear at the top.

## Implementation
- Added `order_key` (not `filter_key`) for the four joined-table columns using PrestaShop's `alias!column` notation. `order_key` only affects ORDER BY, leaving the existing `havingFilter` (which targets the `CONCAT` / aliased SELECT columns) untouched. Using `filter_key` would have caused `HAVING c.lastname LIKE ...` and a 500 because `c.lastname` is not in the SELECT list.
- Set `_defaultOrderBy` / `_defaultOrderWay`.

## Test plan
- [x] PS 8.2.3: All four added columns sort ASC and DESC without errors
- [x] PS 9.1.2: Same, with 217 seeded shipments; latest at top by default
- [x] `havingFilter` still works (receiver_name=John matches CONCAT alias)
- [x] Existing main-table columns (date_print, date_add, reference1, num_of_parcels, printed_label, printed_manifest) still sort correctly