### PR TITLE
DGS-429 Warn on empty pickup point import and keep existing points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,7 @@
 - Fixed Lithuanian and Latvian translations for shipping label in admin order panel
 - Added Poland parcel shop import support with batch processing
 - Fixed null parameter deprecation in AddressAdapter preg_replace calls
+- Improved pickup point import to warn when DPD returns 0 points and keep existing points instead of reporting a false success
 - Fixed shipment creation failing for accounts requiring Predict SMS service
 - Fixed additional validation for supercheckout module using currentcontroller variable
 - Fixed automatic PUDO point pre-selection in LIST mode

--- a/src/Service/Import/API/ParcelShopImport.php
+++ b/src/Service/Import/API/ParcelShopImport.php
@@ -120,6 +120,23 @@ class ParcelShopImport
         }
 
         $parcelCount = count($parcelShops);
+
+        if ($parcelCount === 0) {
+            $this->logger->warning(sprintf(
+                '[ParcelImport] API returned 0 parcel shops for %s | API took: %ss',
+                $selectedCountry,
+                $apiTime
+            ));
+
+            return [
+                'success' => false,
+                'error' => sprintf(
+                    $this->module->l('DPD returned 0 pickup points for %s. Existing pickup points were kept. The web service account may not be enabled for pickup point retrieval - please contact DPD.', self::FILE_NAME),
+                    $selectedCountry
+                )
+            ];
+        }
+
         $dbStartTime = microtime(true);
 
         try {


### PR DESCRIPTION
## What

Improves the pickup point import so an empty DPD response no longer reports a false success and no longer wipes existing pickup points.

## Why

Found while investigating SDESK-231 (account ASAPPOOD, live mode). The import call succeeds and DPD returns status `ok` but with 0 pickup points. The module reported "Successfully imported 0 parcel shops" and, because `updateParcels` deletes the country's shops before inserting, existing points could be wiped while the UI showed success.

Verified the empty response is account-specific: the same live endpoint (integration.dpd.ee) returns 358 EE points for the DPD test account but 0 for ASAPPOOD.

## Change

`ParcelShopImport::importParcelShops`: when DPD returns a valid response with 0 parcel shops, return a warning instead of success **before** the destructive update, so existing points are kept. A warning is logged for traceability.

- No frontend change: the existing JS already routes `success:false` to `showErrorMessage`.

## Test

Ran the real `ParcelShopImport` against stubbed API/DB:

- `ok` + 0 shops -> `success:false`, `updateParcels` NOT called (points kept), warning logged
- `ok` + N shops -> `success:true`, import runs as before
- `status:err` -> existing behavior preserved

8/8 assertions passed. Next phase: QA to verify in a live/staging back office.

## Changelog

Added entry under [3.3.1].

Related: SDESK-231, DGS-429
