### PR TITLE
DGS-430 Add --ignore-platform-reqs to release build

### DIFF
--- a/.github/workflows/create-zip.yml
+++ b/.github/workflows/create-zip.yml
@@ -14,8 +14,8 @@ jobs:
           fetch-depth: 0
       - name: build
         run: |
-          composer install --no-dev --optimize-autoloader --classmap-authoritative
-          composer dump-autoload --no-dev --optimize --classmap-authoritative
+          composer install --no-dev --optimize-autoloader --classmap-authoritative --ignore-platform-reqs
+          composer dump-autoload --no-dev --optimize --classmap-authoritative --ignore-platform-reqs
           rm -rf .git .github tests vendor.zip .gitignore
           mkdir dpdbaltics
           rsync -Rr ./ ./dpdbaltics

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
           fetch-depth: 0
       - name: build
         run: |
-          composer install --no-dev --optimize-autoloader --classmap-authoritative
-          composer dump-autoload --no-dev --optimize --classmap-authoritative
+          composer install --no-dev --optimize-autoloader --classmap-authoritative --ignore-platform-reqs
+          composer dump-autoload --no-dev --optimize --classmap-authoritative --ignore-platform-reqs
           rm -rf .git
           rm -rf .github
           rm -rf tests


### PR DESCRIPTION
The composer.lock pins PHP 7+/8+ package versions while composer.json still declares config.platform.php=5.6. composer install --no-dev then fails with 'lock file does not contain a compatible set of packages', so the release job produced no dpdbaltics.zip and users only saw the source archive without vendor (module invalid and cannot be loaded).

Ignoring platform reqs lets the locked set install as-is so the build attaches the vendor-bundled zip again.