### PR TITLE
fix(ci): ignore platform reqs in release & create-zip workflows

### DIFF
--- a/.github/workflows/create-zip.yml
+++ b/.github/workflows/create-zip.yml
@@ -14,8 +14,8 @@ jobs:
           fetch-depth: 0
       - name: build
         run: |
-          composer install --no-dev --optimize-autoloader --classmap-authoritative
-          composer dump-autoload --no-dev --optimize --classmap-authoritative
+          composer install --no-dev --optimize-autoloader --classmap-authoritative --ignore-platform-reqs
+          composer dump-autoload --no-dev --optimize --classmap-authoritative --ignore-platform-reqs
           rm -rf .git .github tests vendor.zip .gitignore
           mkdir dpdbaltics
           rsync -Rr ./ ./dpdbaltics

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
           fetch-depth: 0
       - name: build
         run: |
-          composer install --no-dev --optimize-autoloader --classmap-authoritative
-          composer dump-autoload --no-dev --optimize --classmap-authoritative
+          composer install --no-dev --optimize-autoloader --classmap-authoritative --ignore-platform-reqs
+          composer dump-autoload --no-dev --optimize --classmap-authoritative --ignore-platform-reqs
           rm -rf .git
           rm -rf .github
           rm -rf tests


### PR DESCRIPTION
## Problem

The latest `v3.3.1` release run [failed](https://github.com/DPDBaltics/PrestaShop/actions/runs/27677554916) — the `release` workflow errored at the first `composer install` step, so the module ZIP was never built or attached to the release.

`composer.json` pins a fake platform PHP version:
```json
"config": { "platform": { "php": "5.6" } }
```
All locked dependencies require PHP ≥ 7.1/8.x, so Composer's lock-file compatibility check fails immediately:
```
Your lock file does not contain a compatible set of packages. Please run composer update.
  - doctrine/deprecations 1.1.6 requires php ^7.1 || ^8.0 -> your php version (5.6; overridden via config.platform...)
```

This exact fix (`--ignore-platform-reqs`) was already applied to `index.yml` in commit 7375297, but never propagated to `release.yml` or `create-zip.yml`.

## Fix

Add `--ignore-platform-reqs` to the `composer install` and `composer dump-autoload` calls in both `release.yml` and `create-zip.yml`, matching `index.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)