### PR TITLE
DGS-431 DGS-432 DGS-433 Improve DPD shipment creation error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,3 +204,8 @@
 - Added timeframes to shipment request
 - Fixed phone area code, city and street select width rendering as 0px when switching carriers in checkout
 - Fixed DPDBaltics menu item disappearing from sidebar when navigating to module pages
+
+## [3.3.2]
+- Improved shipment creation error message to be a clear, readable sentence
+- Improved DPD API authentication error to explain that the API credentials in Basic Settings were rejected
+- Fixed shipment creation error messages not being translated to the shop language

--- a/src/Service/Exception/ExceptionService.php
+++ b/src/Service/Exception/ExceptionService.php
@@ -23,6 +23,7 @@ namespace Invertus\dpdBaltics\Service\Exception;
 
 use DPDBaltics;
 use Exception;
+use Invertus\dpdBaltics\Util\ApiErrorUtility;
 use Invertus\dpdBaltics\Validate\ShipmentData\Exception\InvalidShipmentDataField;
 use Invertus\dpdBalticsApi\Exception\DPDBalticsAPIException;
 
@@ -62,6 +63,18 @@ class ExceptionService
                 $this->module->l('Failed to create courier request', self::SHORT_CLASS_NAME),
             ]
         ];
+    }
+
+    public function getApiErrorMessage($rawErrorLog)
+    {
+        if (ApiErrorUtility::isAuthenticationError($rawErrorLog)) {
+            return $this->module->l(
+                'DPD rejected the API credentials. Please check that the API username and password in Basic Settings match the web service credentials provided by DPD, not your DPD web portal login.',
+                self::SHORT_CLASS_NAME
+            );
+        }
+
+        return $rawErrorLog;
     }
 
     public function getShipmentFieldErrorMessages()

--- a/src/Service/Label/LabelPrintingService.php
+++ b/src/Service/Label/LabelPrintingService.php
@@ -115,17 +115,22 @@ class LabelPrintingService
             return $response;
 
         } catch (Exception $e) {
-            $exception = $e->getMessage(). ' ID order: '. $orderId;
-            $response['message'] = $this->module->l("Failed to create DPD shipment: {$exception}");
+            $response['message'] = sprintf(
+                $this->module->l('Failed to create DPD shipment: %s (order ID: %s)'),
+                $e->getMessage(),
+                $orderId
+            );
             $this->logger->error($response['message']);
 
             return $response;
         }
 
         if ($shipmentCreationResponse->getStatus() !== Config::API_SUCCESS_STATUS) {
-            $exception = $shipmentCreationResponse->getErrLog(). ' ID order: '. $orderId;
-            $response['message'] = $this->module->l(
-                "Failed to create DPD shipment API status failed : {$exception}"
+            $apiError = $this->exceptionService->getApiErrorMessage($shipmentCreationResponse->getErrLog());
+            $response['message'] = sprintf(
+                $this->module->l('Failed to create DPD shipment: %s (order ID: %s)'),
+                $apiError,
+                $orderId
             );
             $this->logger->error($response['message']);
 

--- a/src/Util/ApiErrorUtility.php
+++ b/src/Util/ApiErrorUtility.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+
+namespace Invertus\dpdBaltics\Util;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class ApiErrorUtility
+{
+    const AUTHENTICATION_ERROR_PATTERNS = [
+        'unable to find user to authenticate',
+        'authentication failed',
+        'invalid username or password',
+    ];
+
+    public static function isAuthenticationError($rawErrorLog)
+    {
+        $haystack = mb_strtolower((string) $rawErrorLog);
+
+        foreach (self::AUTHENTICATION_ERROR_PATTERNS as $pattern) {
+            if (false !== strpos($haystack, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Unit/Util/ApiErrorUtilityTest.php
+++ b/tests/Unit/Util/ApiErrorUtilityTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+
+use Invertus\dpdBaltics\Util\ApiErrorUtility;
+use PHPUnit\Framework\TestCase;
+
+class ApiErrorUtilityTest extends TestCase
+{
+    /**
+     * @dataProvider authenticationErrorProvider
+     */
+    public function testIsAuthenticationError($rawErrorLog, $expected)
+    {
+        $this->assertSame($expected, ApiErrorUtility::isAuthenticationError($rawErrorLog));
+    }
+
+    public function authenticationErrorProvider()
+    {
+        return [
+            'exact DPD message' => ['Unable to find user to authenticate!', true],
+            'different casing' => ['unable to FIND user to authenticate', true],
+            'authentication failed' => ['Authentication failed', true],
+            'invalid credentials' => ['Invalid username or password', true],
+            'unrelated error' => ['Parcel weight is required', false],
+            'empty string' => ['', false],
+            'null' => [null, false],
+        ];
+    }
+}

--- a/tests/Unit/Util/index.php
+++ b/tests/Unit/Util/index.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;


### PR DESCRIPTION
## Summary

Improves the error messages shown to the shop owner when a DPD shipment cannot be created. Driven by a support case where a merchant saw the raw DPD error `Unable to find user to authenticate!` and could not tell it meant wrong API credentials.

Covers three separate tickets:

- **DGS-431** - the failure message was broken English (`Failed to create DPD shipment API status failed :`). Reworded into a clear sentence.
- **DGS-432** - when DPD rejects the API credentials, the cryptic technical error is now replaced with an actionable message telling the owner to check the web service API username/password in Basic Settings (not the DPD web portal login). New `ApiErrorUtility` for detection, with a unit test.
- **DGS-433** - error text was baked inside the `l()` translation key, so it never translated. Variables moved out via `sprintf` so messages now translate to the shop language.

## Release
- Improved shipment creation error message to be a clear, readable sentence
- Improved DPD API authentication error to explain that the API credentials in Basic Settings were rejected
- Fixed shipment creation error messages not being translated to the shop language

## Testing
- New unit test `tests/Unit/Util/ApiErrorUtilityTest.php` covers authentication error detection (exact message, casing, unrelated errors, empty, null).
- Detection logic verified against the real DPD error string `Unable to find user to authenticate!`.