### PR TITLE
DGS-437 Fix module CSS overriding theme focus styles on checkout forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,3 +204,6 @@
 - Added timeframes to shipment request
 - Fixed phone area code, city and street select width rendering as 0px when switching carriers in checkout
 - Fixed DPDBaltics menu item disappearing from sidebar when navigating to module pages
+
+## [3.3.2]
+- Fixed module checkout CSS overriding theme focus styles on personal information and address form fields

--- a/views/css/front/pudo-shipment.css
+++ b/views/css/front/pudo-shipment.css
@@ -201,10 +201,10 @@
   text-shadow: 0 0 0 #000;
 }
 
-.search-block-container .dpd-input-wrapper select.form-control:focus, input.form-control:focus {
+.search-block-container .dpd-input-wrapper select.form-control:focus,
+.dpd-input-wrapper input.form-control:focus {
   box-shadow: 0 0 0 2px #2fb5d2;
   outline: none;
-
 }
 
 .dpd-input-wrapper input:not([disabled]):focus ~ .dpd-input-placeholder,


### PR DESCRIPTION
Fixes #176

## Problem

`views/css/front/pudo-shipment.css` applied the DPD focus style to every input on the checkout page, not only to the pick-up point search block. The theme focus style on the personal information and address form fields was replaced by the DPD cyan ring.

## Root cause

The rule was written as a single line:

```css
.search-block-container .dpd-input-wrapper select.form-control:focus, input.form-control:focus {
```

Comma separated CSS selectors do not inherit the prefix of the preceding selector. The second selector is a bare `input.form-control:focus`, so it matched every input on the page.

The stylesheet is registered in `dpdbaltics.php` for the `order`, `order-opc`, `ShipmentReturn` and `supercheckout` controllers, which is exactly where the personal information and address forms render, so the rule leaked onto them.

Specificity is why the module won regardless of load order: `input.form-control:focus` scores 0-2-1 against the theme's `.form-control:focus` at 0-2-0.

## Fix

```css
.search-block-container .dpd-input-wrapper select.form-control:focus,
.dpd-input-wrapper input.form-control:focus {
```

The `select` half keeps its existing scope, that element does live in the search block (`pudo-search-block.tpl`). The `input` half narrows from every input on the page to inputs inside a DPD wrapper, which is the phone field in `carrier-phone-number.tpl`.

Note that scoping the input half to `.search-block-container` would be wrong: there is no `input.form-control` inside that container at all, so it would match nothing and would silently drop the focus ring from the module's own phone field.

## Not a regression

The selector has been in the file since the first commit (702dd3d, January 2021) and is present in 3.3.1.

## Testing

Reproduced and verified on PrestaShop 9.1.3, PHP 8.4, Hummingbird theme, DPD Baltics 3.3.1.

1. Add a product to the cart and open `/order`
2. Focus the First name field in the Order as a guest form

Computed `box-shadow` on that field:

| | Computed value | Source |
|---|---|---|
| Before | `rgb(47, 181, 210) 0 0 0 2px` | DPD `#2fb5d2` |
| After | `rgba(11, 105, 246, 0.25) 0 0 0 4px`, `border-color: rgb(133, 180, 251)` | Hummingbird |

A DPD carrier does not need to be active to reproduce. The stylesheet registers unconditionally for the listed controllers.

Also note that with CCC enabled the module CSS is bundled into `themes/<theme>/assets/cache/theme-<hash>.css`, so there is no `pudo-shipment.css` entry in the network tab. Clear `var/cache` and the cached combined theme CSS after changing the file.

## Impact beyond PS 9

The issue is not PS 9 specific. Hummingbird uses `box-shadow` for focus and already sets `outline: 0`, so the module's `outline: none` is a no-op there and the field still shows a visible ring, just the wrong colour. On PS 8 Classic, `.form-control:focus` uses `outline: .1875rem solid #24b9d7`, so the module's `outline: none` removes that indicator instead of restyling it. The accessibility impact is worse on Classic.

## Follow-up, not included here

Line 223 of the same file has the same class of problem:

```css
a.chosen-single:hover {
  color: black !important;
}
```

This is unscoped and would affect any theme using the Chosen library elsewhere on checkout. Left out of this PR because scoping it correctly needs a check of which Chosen instances the module owns, and I did not want to risk regressing the module's own phone area code select in a fix for #176. Happy to add it here if you prefer it in one pass.

## Verification gap

That the module phone field keeps its cyan ring after this change rests on reading `carrier-phone-number.tpl` (the input is `class="form-control"` inside `.dpd-input-wrapper`), not on observation. All DPD carriers in my test shop are inactive and activating them needs DPD API credentials to fetch products and zones, so the phone field does not render on the front end. Worth a quick look on an environment with a live DPD carrier before merge.
